### PR TITLE
Fixes an issue with the sourcemap file and sources property

### DIFF
--- a/tasks/6to5.js
+++ b/tasks/6to5.js
@@ -13,6 +13,9 @@ module.exports = function (grunt) {
 			grunt.file.write(el.dest, res.code);
 
 			if (res.map) {
+				res.map.file = options.filename;
+				res.map.sources[0] = options.filename;
+				
 				grunt.file.write(el.dest + '.map', JSON.stringify(res.map));
 			}
 		});


### PR DESCRIPTION
When transpiling multiple files, the sourcemap `file` and `sources` properties always reference the first transpiled filename.

My configuration:
File `a/b.js`
File `a/c.js`

Grunt config:

```
6to5: {
      dist: {
        files: [{
            expand: true,
            cwd: 'a',
            src: ['**/*.js'],
            dest: 'tmp/'
        }]
    }
}
```

While I'm not entirely sure this is a `grunt-6to5` issue, I tried to reproduce this bug with the `6to5` command-line tool, but it worked perfectly when using the command-line tool.

This pull request modifies the properties, so the reference to filename in the sourcemap is always the filename of the current transpiled file.
