### PR TITLE
Support for nested options

### DIFF
--- a/tasks/babel.js
+++ b/tasks/babel.js
@@ -9,6 +9,10 @@ module.exports = function (grunt) {
 		this.files.forEach(function (el) {
 			delete options.filename;
 			delete options.filenameRelative;
+			
+			if (el.options){
+				options = el.options;
+			}
 
 			var res = babel.transformFileSync(el.src[0], options);
 


### PR DESCRIPTION
We have cases in which each block needs a different set of options. For example we have this config, where client needs the map file while server doesn't
```
  babel: {
      client:{
        options: {
          sourceMap: true
        },
        src : ['client/**/*.js', 'client/**/*.jsx'],
        dest : 'dist'
      },
      server:{
        options: {
          sourceMap: false
        },
        src : ['server/**/*.js', 'server/**/*.jsx'],
        dest : 'dist'
      }    
    }
```
I don't know if others have the same problem, but doing that small change help me in resolving my issue.