### PR TITLE
Fix #27 - use correct 'sources' and 'file' in sourcemaps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function (grunt) {
 					sourceMap: true
 				},
 				files: {
-					'test/tmp/fixture.js': 'test/fixture.js'
+					'test/tmp/fixture-compiled.js': 'test/fixture.js'
 				}
 			}
 		},

--- a/tasks/babel.js
+++ b/tasks/babel.js
@@ -10,6 +10,9 @@ module.exports = function (grunt) {
 			delete options.filename;
 			delete options.filenameRelative;
 
+			options.sourceFileName = path.relative(path.dirname(el.dest), el.src[0]);
+			options.sourceMapTarget = path.basename(el.dest);
+
 			var res = babel.transformFileSync(el.src[0], options);
 
 			var sourceMappingURL = '';

--- a/test/test.js
+++ b/test/test.js
@@ -3,14 +3,15 @@ var fs = require('fs');
 
 exports.babel = {
 	compile: function (test) {
-		var code = fs.readFileSync('test/tmp/fixture.js', 'utf8');
+		var code = fs.readFileSync('test/tmp/fixture-compiled.js', 'utf8');
 		test.ok(/function/.test(code));
 
-		var map = fs.readFileSync('test/tmp/fixture.js.map', 'utf8');
-		test.deepEqual(JSON.parse(map).sources, ['test/fixture.js']);
+		var map = fs.readFileSync('test/tmp/fixture-compiled.js.map', 'utf8');
+		var json = JSON.parse(map);
 
-		test.ok(/\/\/# sourceMappingURL=fixture.js.map\n$/.test(code));
-
+		test.deepEqual(json.sources, ['../fixture.js']);
+		test.deepEqual(json.file, 'fixture-compiled.js');
+		test.ok(/\/\/# sourceMappingURL=fixture-compiled.js.map\n$/.test(code));
 		test.done();
 	}
 };


### PR DESCRIPTION
This change fixes two properties in sourcemaps file: `sources` and `file`

Generated output is consistent to using Babel from the command line:

`babel --source-maps --out-file tmp/fixture-compiled.js fixture.js`

This is an addition to the work of @luhn in https://github.com/babel/grunt-babel/pull/41