### PR TITLE
Fix paths on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/test/tmp

--- a/tasks/babel.js
+++ b/tasks/babel.js
@@ -10,7 +10,10 @@ module.exports = function (grunt) {
 			delete options.filename;
 			delete options.filenameRelative;
 
-			options.sourceFileName = path.posix.relative(path.dirname(el.dest), el.src[0]);
+			options.sourceFileName = path.relative(path.dirname(el.dest), el.src[0]);
+			if (process.platform === 'win32') {
+				options.sourceFileName = options.sourceFileName.replace(/\\/g, '/');
+			}
 			options.sourceMapTarget = path.basename(el.dest);
 
 			var res = babel.transformFileSync(el.src[0], options);

--- a/tasks/babel.js
+++ b/tasks/babel.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
 			delete options.filename;
 			delete options.filenameRelative;
 
-			options.sourceFileName = path.relative(path.dirname(el.dest), el.src[0]);
+			options.sourceFileName = path.posix.relative(path.dirname(el.dest), el.src[0]);
 			options.sourceMapTarget = path.basename(el.dest);
 
 			var res = babel.transformFileSync(el.src[0], options);


### PR DESCRIPTION
Use `path.posix` to make sure the paths are consistent across all OS. This fixes tests on Windows.