### PR TITLE
Babel 7 has moved to @babel namespace

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function (grunt) {
 			compile: {
 				options: {
 					sourceMap: true,
-					presets: ['env']
+					presets: ['@babel/preset-env']
 				},
 				files: {
 					'test/tmp/fixture-compiled.js': 'test/fixtures/fixture.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,597 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.35.tgz",
+      "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "@babel/core": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.35.tgz",
+      "integrity": "sha512-+frqefsq9klDZfK2nLjpqeodicqdJX43xUlz/7acxEd4jEbAQbeKrsgrSo/bwXI4nQ/9f9kXKaZchwdIo8LVtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/generator": "7.0.0-beta.35",
+        "@babel/helpers": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "babylon": "7.0.0-beta.35",
+        "convert-source-map": "1.5.1",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11",
+        "resolve": "1.5.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-5QO6oYlc5xpbZEBFcxdUfzNvtjTwKfttfqkkZZ8FCs7CQwmtqzZMzFvYc+pa8QmMxUF5D8c1+XI/mOy3lYjK7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.35.tgz",
+      "integrity": "sha512-bc2idaE5XgHlyZX7TT+9ij2hhUFa21KVffQY6FTwDRT8BgqgFhIzLMFLRfk7Bd9jj+YwuydHCbdp5jXbeGFfRg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.35.tgz",
+      "integrity": "sha512-lOj12qKqI4hY0KcgyRyaCMp+OEIwuBC90+jrRgHsMmNED//SdcI3TBIDAjBt9fAp3AejS+5eHs374uQQMoPRLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.35.tgz",
+      "integrity": "sha512-/pPdGpmi6t8Vj5dAYfAtQ6RRi140VdHh5wAB47ZgqfTfu/atIPOOKoln2PxvNwTGDkKVykmHdyqqOT7YEan76w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.35.tgz",
+      "integrity": "sha512-bS+6/gvj/iq4TtGZuL2//X7RunihWjS+Hp2o/3cPopvU3CK9IPFPpPZc7NiqjPcvlUc47lzHRO+uk77GBONojQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.35.tgz",
+      "integrity": "sha512-GNw4audVWvYOM16+s/ROMt2n37XKCqdJYWxY4eDeEWCcWU2GxoY8+8DYl2dcxUkMHlJ7KV9lNmkPdPHSSyni7A==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.35.tgz",
+      "integrity": "sha512-+216NxQ7/Lvj+iehFBKEhYU/BQ1aqHTWz1bxCDiQWms0qi23iqHA4r+WdRKW/o5dAV5mlTUL4nCBFaNx8LNnRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.35.tgz",
+      "integrity": "sha512-8co9nT1MgbNoGl6too2/jwldu5F7O1rMi+/QsM9bmFuCu76rU5okFWi4cb4Uv0WXZ4BWk6x+Lpdzzu7EgvkAwA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.35.tgz",
+      "integrity": "sha512-fbdw4Aa/RGvzTZ8fktOZvaz+6w2mP62jwiwnCdKxSQ/dvu4WLAxMmoG5j0kKpE43IvYm0S5UDMvHrKyGX8xd3A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.35.tgz",
+      "integrity": "sha512-vaC1KyIZSuyWb3Lj277fX0pxivyHwuDU4xZsofqgYAbkDxNieMg2vuhzP5AgMweMY7fCQUMTi+BgPqTLjkxXFg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.35.tgz",
+      "integrity": "sha512-2d2wk8WAPv98avaLLn8tUSNilgPDF1On+y50WKZV6rr6tKZwtmotrL7iyIUIYRU1FGfJ5lkh6ApOIghX17ZfGA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.35",
+        "@babel/helper-simple-access": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.35.tgz",
+      "integrity": "sha512-hr/P3XTAtN5wppGLP4yrOUbvIyOQPmEG6EVsCSE5z0yUueNQzuCxXp0v7sx7/V+c0eP3XLy/lVsuM96cS3VUKQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-n8nsrxmamIy/HqeS+KXiZaZhaElRMTxKzQl8OAOXqllQQ/T4FQEiGyyqdHsjpbd2JmaLT6875Z8uneK7kk+pdg==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-Ud5eajQ0HRDLN5wMSrEIa+MBgrlcIjTnX0zKyG5YoGBF9jWXLaapH4XUVsyxiprQyc3Y0rAbhMihz7JxAYplmg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.35",
+        "@babel/helper-wrap-function": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.35.tgz",
+      "integrity": "sha512-ez6sOMdXeFzGlg2Qbyi//2nbBrftC7RzMpN671Hd87ITP2af3feEWYEKC5O0EXLCcgaNBzNntkScRGV9ez03wg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.35.tgz",
+      "integrity": "sha512-wMUSdnxUEbcVXMeE2YG9sLvxetXVf5Ye3GSKpu0oVzbRkTcKpcauJW3ukTBquPMuiPAa2sLlvk0ZS6zGe0/PHg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.35.tgz",
+      "integrity": "sha512-Pp3/4agQAldsoX9WtntyVq9yWOl3xuNxlMnqXCspYaJeBlvs4+oX1D3AvTS0ogG2mBMGwJm6wYbI3s8a8IYF8g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.35.tgz",
+      "integrity": "sha512-2MplGn7unCRsK3G/serxBbVIhm7ntgf/KmnsIjXbSpK1TKMLVu1WyXIcIHGWGgo5FB5/d2OxiNtygM56v7190Q==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "7.0.0-beta.35",
+        "@babel/traverse": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-check-constants": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.35.tgz",
+      "integrity": "sha512-p60C6MNtY8ZnO9mGDaDaKi1Sd3HXl41IrYtAt79oWORmI23fwnPNkWSV1pgh1SrySHE4loqZEwwy8Cej8zaT5Q==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.35.tgz",
+      "integrity": "sha512-2YClvzIll/q8UC5+7uLHUAt836/MAHWyX22HVaNKIdpRTY7bys+YW/K0GJ0GM2AlyYwDIu/MGfNPiyW336j4Pw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.35",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.35.tgz",
+      "integrity": "sha512-ZIlSeE1YbCqTRjGovxD/+GAzeByqG15f0BQI9oEelvC9SKCCOEslAirqWLhc4MXjwSGW/lE9RlFgdwPNf39fBQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.35.tgz",
+      "integrity": "sha512-9Rj3kLA1hjaIYwEOXBve6OGgbA32HqFZnXlT14KsT2PeZfNevQXQhPRde2XcdUzS71p1be8G5JE0R95nXmTyEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-4SBY3ghnwHZNA8VpvuR7QQPo0cYSQ8vQCvAGzYWBDSpQ0vtuOOgwnxOnGy+mGC3o0t7ZyFcu0IaRWpYHP58FWQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.35",
+        "regexpu-core": "4.1.3"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.35.tgz",
+      "integrity": "sha512-i6igBBo3ED9CyvtwnBjgYkD6x3qJU5B9h97bU6DVaCGbaJKTFfqv8z+4JAO9JG96cfod5aiYdoDbdawfAoX1LA==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.35.tgz",
+      "integrity": "sha512-iqaA0VdD6ajunwXpI92kSaxgrfP/Dqo/LQ+Q33qhfSKvLH/00WfeCfhoD3M0cLzo0tB6STrh/IUCDJAoiFTW7A==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.35.tgz",
+      "integrity": "sha512-RNr1NuPGLSBL+5vQq7hvDm6FPQyK+E6rKVlEwMFTyHNq584J305hC6ZFDtt9TqVDN00yBfldguSUikHNZSyfnw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.35.tgz",
+      "integrity": "sha512-PO5ZsTmBtazAfV+Q9KZJPCunmcJwyKW4YNDQuxnnPpiLx4naY+t2zcelO210RoBxTr9IdrjLOXurT/+20wBJTg==",
+      "dev": true
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-vPlHoCv0DKJuawuk0/1GdqGwKNkVDVsbauVJTrdccSG0Vll867RRvBKWXb6fV++2kvXwVFEzBE5+1FHHUaWmOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.35",
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.35.tgz",
+      "integrity": "sha512-meMmY4WHWALANTGMbfnTUwzpRRoJO4CQubz9+Xqn9/KB4OF9Rz4J2CvEX/QBKXVxdwzBncJH7lkg9nJWaLTtpw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.35.tgz",
+      "integrity": "sha512-6PytBpASHBhPi9pSyOnCip6ZXsOu0yd5ufjs8A06coeVlp6R57IMGOBD8Klk29FUS+FJo367G2s8PxUKDuFQgw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.35.tgz",
+      "integrity": "sha512-D71nw+Brh7IWSHiW4/JDux5EhT4gyMYG1WJVjaXl6D6DQhOFlZf5otUVrVX6IxEQaco3B2dlEBDEt/UXvf9E2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.35",
+        "@babel/helper-define-map": "7.0.0-beta.35",
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.35",
+        "@babel/helper-replace-supers": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.35.tgz",
+      "integrity": "sha512-m94sLp/9ktRWRRoMkFkCho2nfURK17JLnJEAIvdn1zPfSGmguq3vk4tfFNQKVZ9lE8W1LlqDdE/2bXVdh7UbzQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.35.tgz",
+      "integrity": "sha512-TL59Z2iI5ohs0jMTq+EGdAB9QWr3SU1XzGisG7ogJe1IX+osupo4Pgd3fxH2hbgtq+QpKM+8DXaKQG/xKDlx6w==",
+      "dev": true
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.35.tgz",
+      "integrity": "sha512-K6/BsBT+oIScy2rvGWP6WWWB1ayU0FNV4rsvHGx2mS4o5G/OmFz52PhViDQxWEoNbU7+2Z263CNgjelzPsX5oA==",
+      "dev": true
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-EC1kqX9stnSzfC8pUxjJZRkeOY4dPtDQtDQBhQVwJZG1NkinJPVlzs0/r0kCQUtBfpmmCvZwKYmsnv02wvqQmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.35.tgz",
+      "integrity": "sha512-iBefZVo6LLNILCaaa5530OANwqQHXjHtu3vdiL9M9A5r0ULj2kAqSNKkMDvQ0Yaxe0M7VzUOHVsWoUzrSDH6lQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.35.tgz",
+      "integrity": "sha512-qHVKPcszzmg6mOJv4Q13zGwmN5hG24yQWVQCtYxpuTIFxu/3EUSI42ocp9hPABw9BhnEI2RiXq82s/2olWglqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.35.tgz",
+      "integrity": "sha512-f98iHJ3fhO5OPP2kijlQ7+kNibbUsSkEVQ28CAA81JtT4fifZUfPgA0S3Piao0fNmxIY6JwSpUH/i+8mRWhfpQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.35.tgz",
+      "integrity": "sha512-0zC8M7Ud8kj8s6/lhyoXM+R3ted522NEe2/EUGjOjhsekyyFs54p34yMPpN/OxDjMHPHpSYmEgrV0HFdtOdx/Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.35.tgz",
+      "integrity": "sha512-cg7TRAV1cu92Mk9XYQHsedgZYwaJ+Gc8UakB1d6XiO1+HcP/FsIQgt/1Pa+hAdamwmuEksSKD452JRz5TSGO7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.35",
+        "@babel/helper-simple-access": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.35.tgz",
+      "integrity": "sha512-oHGov6ZhsAQeGW9Gpz7Otrau927948oi1khhKS7GmXcTalDpublxDWcji8FfcJXWt6tyuxVPweuxtTTjeUmtqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.35.tgz",
+      "integrity": "sha512-dWLdxQVQGbgdKWkHkgZuIGVnNiaegqzR3aURgIYIVL3qF2Vo/PnKXNNGnWOSBTSq/lW1oVRi+crj0XmcQR0r5w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.35.tgz",
+      "integrity": "sha512-d/OIA9VIrXHPc5gMqJa1KKIHGlo8qmpIIQJ4qF9TUeTBoRfSyjI6R656d25pjeaswIKndKTtdfngFRhwguXBSA==",
+      "dev": true
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.35.tgz",
+      "integrity": "sha512-oEPs8cPd5vAYExYWjBECl84ZOjFUj0lLGs0vrUn9jy5nbrhGQi9mjfKs8kV0kmoXsFLXD3LLrsJj4G4JPndvMA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-replace-supers": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.35.tgz",
+      "integrity": "sha512-mkDK9XjLcJ66WsfjjAbCzEsJnn7KRKt9osD1MvnVPJ2v2QaRGeh+eHKlENisRj6itk/zhxpcTe8jG/ObnM1PNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "7.0.0-beta.35",
+        "@babel/helper-get-function-arity": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.35.tgz",
+      "integrity": "sha512-P621u2eXvPyzkVZd6mAw7omaAZLkZoLF66CavxEsW4YTbeO9aDBM/GgrvbaNUrffv9DfvFbLZVbvJ6LAXSEVYg==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.12.2"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.35.tgz",
+      "integrity": "sha512-wjWlYd3fxEX1ptGYbxSvXAN+vfPEP7dSL+OXlWB0pVUXuZQYJu9aq9BNZl5gC4slMp2nC7HmHG4KzsTZ3sTCjQ==",
+      "dev": true
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.35.tgz",
+      "integrity": "sha512-AaAtOXICT58RER/pgbVR8OlpNAp5JZ90hzUUNqpdg53XFom/Mfb/+JYk9amaPmiEUA+eJtr102PqvclrW5ckWw==",
+      "dev": true
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-EEzzZi61o/4VZzb5nhcNlZ7NPpRLOviUu+SpcTYIQCf1s9QdoyQ8gqb3+3x3vLhwRcKDe8gLee8INXk3Ebg//g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.35.tgz",
+      "integrity": "sha512-sWkmgwFvztzS9c3FVA4sutoy42QzaPvDOirK1LHK7iv7CfS7VTK4yn71McgKmzq0tjxoRo7fSZ0DfmEf2/N22w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "7.0.0-beta.35"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.35.tgz",
+      "integrity": "sha512-NzzikFdDh278dKxlwEG51YTtZj/siAebcbLILL00dM/McDrLETnz7WftfDFpVDvbFem9dLf0y59cq9/br6dp+w==",
+      "dev": true
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.35.tgz",
+      "integrity": "sha512-XOFj2eDgoRyVYxbkGeM/1MKZIG79vJgg4UOYPCuJfDF/LkASE88mKMdc24VOch5sfyK+rCr7eFwA3e7MtUfkLg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.35",
+        "regexpu-core": "4.1.3"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.35.tgz",
+      "integrity": "sha512-yjXgDXg3lhiKoCVx16af7Toir8/+fYeOK14MnMXnpRg0dDNnsQXQS4gOzp0bEVYejuGKa19pm1BKKPUpUvGKFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-check-constants": "7.0.0-beta.35",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.35",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.35",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.35",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.35",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.35",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.35",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.35",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.35",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.35",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.35",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.35",
+        "@babel/plugin-transform-classes": "7.0.0-beta.35",
+        "@babel/plugin-transform-computed-properties": "7.0.0-beta.35",
+        "@babel/plugin-transform-destructuring": "7.0.0-beta.35",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.35",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.35",
+        "@babel/plugin-transform-for-of": "7.0.0-beta.35",
+        "@babel/plugin-transform-function-name": "7.0.0-beta.35",
+        "@babel/plugin-transform-literals": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-amd": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.35",
+        "@babel/plugin-transform-modules-umd": "7.0.0-beta.35",
+        "@babel/plugin-transform-new-target": "7.0.0-beta.35",
+        "@babel/plugin-transform-object-super": "7.0.0-beta.35",
+        "@babel/plugin-transform-parameters": "7.0.0-beta.35",
+        "@babel/plugin-transform-regenerator": "7.0.0-beta.35",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.35",
+        "@babel/plugin-transform-spread": "7.0.0-beta.35",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.35",
+        "@babel/plugin-transform-template-literals": "7.0.0-beta.35",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.35",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.35",
+        "browserslist": "2.10.0",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.35.tgz",
+      "integrity": "sha512-NLd3Dfs8hmkxPvaD8ohNtEp9WXp48lxpW//6fXcT9bJWIO3isrH3OTYL9kjX7xFPPasJ1E9bUNSaPFUUgvPZSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "babylon": "7.0.0-beta.35",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.35.tgz",
+      "integrity": "sha512-oj2mjz/20iiDt+X0mlzE2IEkzLyM0nmT1zSUy/6i6vyzitVeoyRaHoM7O81gmAHSfBSqyjWRU0OuD9VIUgj8Vg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/helper-function-name": "7.0.0-beta.35",
+        "@babel/types": "7.0.0-beta.35",
+        "babylon": "7.0.0-beta.35",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.35.tgz",
+      "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      }
+    },
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -71,10 +652,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "argparse": {
       "version": "1.0.9",
@@ -176,159 +760,39 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
-      }
-    },
-    "babel-core": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-F7/vos5H4N5Mv+TZU1CgJ/zJ5bk4JXK83YC+zqhhURH6muxnRKgWYWkVbqVTLmHUrwVn8GCufQdkpAQ3tNPeJA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "7.0.0-alpha.19",
-        "babel-generator": "7.0.0-alpha.19",
-        "babel-helpers": "7.0.0-alpha.19",
-        "babel-messages": "7.0.0-alpha.19",
-        "babel-template": "7.0.0-alpha.19",
-        "babel-traverse": "7.0.0-alpha.19",
-        "babel-types": "7.0.0-alpha.19",
-        "babylon": "7.0.0-beta.19",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "micromatch": "2.3.11",
-        "resolve": "1.4.0",
-        "source-map": "0.5.6"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "babel-code-frame": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
-          "dev": true,
-          "requires": {
-            "babel-helper-get-function-arity": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-messages": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw==",
-          "dev": true
-        },
-        "babel-traverse": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "7.0.0-alpha.19",
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "babylon": "7.0.0-beta.19",
-            "debug": "2.6.8",
-            "globals": "10.0.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.19",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "globals": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.0.0.tgz",
-          "integrity": "sha512-kxN6RfO/HLQcHV2yI48enVP37K7vlpTl3vcLCwYkRidzO/GjOOK7jQUD9LvhPeSvbiAsnSDGEd5SDVVa9EeimQ==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-          "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.5"
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -339,467 +803,19 @@
       "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
       "dev": true,
       "requires": {
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
         "lodash.assign": "4.2.0",
         "lodash.pickby": "4.6.0"
-      }
-    },
-    "babel-generator": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-G3/pJeI3V6dOR7ztt9qeRDqgBc8l5iovb7B1RUFJNDmGb8ZlcGkYyeKv7PEPtIprcbgOKc13yWx3xKc5UbUi7w==",
-      "dev": true,
-      "requires": {
-        "babel-messages": "7.0.0-alpha.19",
-        "babel-types": "7.0.0-alpha.19",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
       },
       "dependencies": {
-        "babel-messages": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw==",
-          "dev": true
-        },
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-Kgzqk2IE3ZZfIT4q1t9wYXof6UdyWeMKSvaZ3CCdl7LK/d0fZ40INuMraTJM7KIfkzNLBZ3orbJ+XT1wh6gYJA==",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "7.0.0-alpha.19",
-        "babel-types": "7.0.0-alpha.19"
-      },
-      "dependencies": {
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-cZ+QtUivFrjS57zrlnmnA8vYs03l5gYXIhy3NWit1rYKmjJGOsQ3VLEulGRtdicgcEQtU0WWk2uVUnyT1HAVmg==",
-      "dev": true,
-      "requires": {
-        "babel-traverse": "7.0.0-alpha.19",
-        "babel-types": "7.0.0-alpha.19"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "babel-code-frame": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
-          "dev": true,
-          "requires": {
-            "babel-helper-get-function-arity": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-messages": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw==",
-          "dev": true
-        },
-        "babel-traverse": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "7.0.0-alpha.19",
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "babylon": "7.0.0-beta.19",
-            "debug": "2.6.8",
-            "globals": "10.0.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
         "babylon": {
-          "version": "7.0.0-beta.19",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "globals": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.0.0.tgz",
-          "integrity": "sha512-kxN6RfO/HLQcHV2yI48enVP37K7vlpTl3vcLCwYkRidzO/GjOOK7jQUD9LvhPeSvbiAsnSDGEd5SDVVa9EeimQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         }
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-WQ7yQA2jk1OFL4lVL6t250rXfqGaMSQ1UJHQSx91N9QVUw/JNkRx3NBAo2iypEXWFFBQ1GvdEns0SZ4XjqEaOw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-wrap-function": "7.0.0-alpha.19",
-        "babel-template": "7.0.0-alpha.19",
-        "babel-traverse": "7.0.0-alpha.19",
-        "babel-types": "7.0.0-alpha.19"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "babel-code-frame": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
-          "dev": true,
-          "requires": {
-            "babel-helper-get-function-arity": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-messages": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw==",
-          "dev": true
-        },
-        "babel-traverse": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "7.0.0-alpha.19",
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "babylon": "7.0.0-beta.19",
-            "debug": "2.6.8",
-            "globals": "10.0.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.19",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "globals": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.0.0.tgz",
-          "integrity": "sha512-kxN6RfO/HLQcHV2yI48enVP37K7vlpTl3vcLCwYkRidzO/GjOOK7jQUD9LvhPeSvbiAsnSDGEd5SDVVa9EeimQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helper-wrap-function": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-helper-wrap-function/-/babel-helper-wrap-function-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-Vf0gzM3wOFEB6aJhnqFdR+bfmn53q2YOvQxQL7x2LQ85GSJdHyY3OVh+//hv/pOAdfdyD/2oJKNYK4wGJZtbtg==",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "7.0.0-alpha.19",
-        "babel-template": "7.0.0-alpha.19",
-        "babel-traverse": "7.0.0-alpha.19",
-        "babel-types": "7.0.0-alpha.19"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "babel-code-frame": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
-          "dev": true,
-          "requires": {
-            "babel-helper-get-function-arity": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-messages": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw==",
-          "dev": true
-        },
-        "babel-traverse": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "7.0.0-alpha.19",
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "babylon": "7.0.0-beta.19",
-            "debug": "2.6.8",
-            "globals": "10.0.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.19",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "globals": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.0.0.tgz",
-          "integrity": "sha512-kxN6RfO/HLQcHV2yI48enVP37K7vlpTl3vcLCwYkRidzO/GjOOK7jQUD9LvhPeSvbiAsnSDGEd5SDVVa9EeimQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helpers": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-2AdJGQ+HK0tbYAAbVw+yudMQnZI6SOl/a2EuJYA066SfycE6bfN6F+KG9z2A7N2PlljEFrosawHKL1qNQsG8hg==",
-      "dev": true,
-      "requires": {
-        "babel-template": "7.0.0-alpha.19"
       }
     },
     "babel-messages": {
@@ -808,696 +824,83 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
-      }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-8TrgRevIg/m3wCZNbUpr4FZgRzK5L91MLP6zchVWWR4mx/iRGR+Pg0Ubqg8YHk/kcpqVt5+aF2vteUEeIyONYQ==",
-      "dev": true
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-IGC73y9d7VMTadK+U5J3O25XPyQGw5PN8m4jkBJbqJratzxeukgLx6uw9FgV07bGu5hudmZSsY7bd4GswnRQwA==",
-      "dev": true
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-3QfJjQdzi2IERdmrEAoOdPPROX5jx2pnqh9Ao4qr3NGx8j9XnfTpIF/YRBu/P1PtaDCtTT8Mtw7AH72QKPr7kQ==",
-      "dev": true
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-T4IKT0P32yEp0TCUGttOJsIcfiHBfc4fYO96CYF3tVYaCBbinzYluo4THNSffLDmVDRr7N1ZYFG/jE7jGyWjWw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "7.0.0-alpha.19",
-        "babel-plugin-syntax-async-functions": "7.0.0-alpha.19"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-AA7SV7XYusZtbxd4wc7ivLdXIZFVmjKBErZVN6T0Iwf0ah0qJHXEIaN0K0yt+lE2hCYi5IWCOESXZf3H4TB+uQ==",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "7.0.0-alpha.19",
-        "babel-plugin-syntax-exponentiation-operator": "7.0.0-alpha.19"
-      }
-    },
-    "babel-preset-env": {
-      "version": "2.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-2.0.0-alpha.19.tgz",
-      "integrity": "sha512-Q1CoVeetTZJcjYHUhCqisOdJ/q2gNAXAgs8KxAo7WJIPBs6Tgb1WRbuMzirhQqXHLS4r5q/AofaFaP6p+vKSlg==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "7.0.0-alpha.19",
-        "babel-plugin-syntax-trailing-function-commas": "7.0.0-alpha.19",
-        "babel-plugin-transform-async-to-generator": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-arrow-functions": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-block-scoped-functions": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-block-scoping": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-classes": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-computed-properties": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-destructuring": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-duplicate-keys": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-for-of": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-function-name": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-literals": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-modules-amd": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-modules-commonjs": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-modules-systemjs": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-modules-umd": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-object-super": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-parameters": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-shorthand-properties": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-spread": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-sticky-regex": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-template-literals": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-typeof-symbol": "7.0.0-alpha.19",
-        "babel-plugin-transform-es2015-unicode-regex": "7.0.0-alpha.19",
-        "babel-plugin-transform-exponentiation-operator": "7.0.0-alpha.19",
-        "babel-plugin-transform-regenerator": "7.0.0-alpha.19",
-        "browserslist": "2.3.0",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "babel-code-frame": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-call-delegate": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-V4Yw9Ycqv9/u/E2Sulr3kR03gix5HDnU1agd4E4TmMXd/43zmPmss4KfN10dt6uCW8gzc0QJR5FtgUgTda/49g==",
-          "dev": true,
-          "requires": {
-            "babel-helper-hoist-variables": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-define-map": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-c5V4TbjIqXoK2zYC4s1Il59/KQVOnpWrdcv47M9OjKBIv8cfzWcfBeFoNGSojxOr5r1dUdDMK2jeYv8EAyk+Rg==",
-          "dev": true,
-          "requires": {
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
-          "dev": true,
-          "requires": {
-            "babel-helper-get-function-arity": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-hoist-variables": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-9swiDoVZD6qL7dMDb/tysYmZIKvXY38xohvsLqZN1A8jIaDk8nybWkt+bZwsT00VSaeBJo4/YP7ERjXf2/Tj1w==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-optimise-call-expression": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-SP7vqqjhZcvzwu5P/Xrr2So8aSBtwwCjQu5aOmjZgq2/HIkIfpqOdz6ud6B5g7I/mfQvE81EWM8qfCUSstdPyA==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-regex": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-3xJn9/GgIArETMkxm6+sA8XuLMDittJYZI9bY0iwDc8Vp6ChDJ+jHsSDSjpPti0o7zBkecIeyaNAjVktRKgCcw==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-helper-replace-supers": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-/lofcpgP/OaommQKeMD3GSNQjAQIYJr9SARkaA7OPkChP0x4p4EnU1PF77hfDy04N69VnAfCYhrojJLB4mekhg==",
-          "dev": true,
-          "requires": {
-            "babel-helper-optimise-call-expression": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-messages": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw==",
-          "dev": true
-        },
-        "babel-plugin-check-es2015-constants": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-xOzUuP2Rt261qBlwK/3lPOWqE5NOFN2wNYDUdEy5ENelLwuFEglAbnn33Lo/AvY7QXzvrHAjCxmfHEbF5Z1dkQ==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-yrf4c+1IUUJptxlXKN2pnd9ebT6+ctmOQHAiwX1IEGQUMWSoffhybElAPcykR6MVZUzj1Fcb508wqEoBH8DZcw==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-JQ2Q6YrQuw1UdAb4Ol12AIxv5i1mC5Le6ACOK/o3I36zxS3MQEWzIOpm86We7jN6ZYVHT9HI9oqjJrapXgLyKA==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-ezJuaiWwF3Yly8GO+AByhb2MyqbSZ0QeT7mkjyysyHnefrqUDjy0Bt0hdHaoNBGr9PB/m/fI/5+F6MpFNJCzwQ==",
-          "dev": true,
-          "requires": {
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-plugin-transform-es2015-classes": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-RF2TjLSh0+BbNvl+WeWdrLSKiW9ebO1/5rAsPFI1m+I4eC3DXWBFpKyqTZX/cdd9JAOpL5RMEtdp3FvXagBI2Q==",
-          "dev": true,
-          "requires": {
-            "babel-helper-define-map": "7.0.0-alpha.19",
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-helper-optimise-call-expression": "7.0.0-alpha.19",
-            "babel-helper-replace-supers": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-4Y/ebvp+62ROaz6yQe9Xj5h6Z/XphuFyFgT7uwGO3X6Zr9hfLi4bjymTVQUT52EPhO2MA+JgwTbcSMLSR8ZZng==",
-          "dev": true,
-          "requires": {
-            "babel-template": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-9kcQAwAOkEBH9EQxrC14LUX+S6yPoexgbiC8EjMVx0MlPqcEkRU49PZOmYqPJg6yoV7wiR7OHyb1tw7kzSNZzQ==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-w+BeaxZWXbSEZM8UiX97RAIy6NhL1re9xwJzmi/94tA4O0EgohGD6e0O3VpzMLB90R1uoksmwD+PcnqPx0Gscg==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-tcK8FnU1wXfvYoy/1QjnVaPGZGkLay+m0B3qSr+JzLzWlekiZBei9M2A6PL2b5h4E6pIQs2VYHFl+dRqO2NQ/A==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-function-name": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-5mpEyaP2iTlJJKCmazJaK+cogPDa4rdF9NX3wlmUhA47oRNe9vtvEnZPCkG6gxwNz9G672rmjXmXpap07PEp6A==",
-          "dev": true,
-          "requires": {
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-literals": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-Sd1TGhE7EGb1JqFcw1bkhINu+WFXVmzirtfdYyuVyLDQDJpsmF8E2lhdeCtWK9ZreFEV1335Y4z5VoMyZV7+QA==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-vFrFDtXn3iyHysYwXpaNJv3xV4YSWT5/LAxZTOpJHisZTEyueNe7akIrsZdWR0S3PnVBMOZVpWS2uD3i9Fyv2Q==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-transform-es2015-modules-commonjs": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-DIRp/vKPxcQiVhxcsWKjBtag3weJl9wanliUNdNqTyCD0+5fLAIKLqONU8CasPr5OH2uSfCMRo6w7BF3bzO7Dg==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-transform-strict-mode": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-E0u/sEI6B6d1TFFW4v1bEJlFNm8a6RicsNyy3bIpRvS8wtY5RVXKEaqn7ZgzXBBPgBciiqn/JrQMrpMtr75fZQ==",
-          "dev": true,
-          "requires": {
-            "babel-helper-hoist-variables": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-9CVtEzzqj64x9PPeBXzOPKYxRos4u8Z0b1LWWI/K7BEIHWL91C07RLCLYAwnOec9jAU3oy64/gysOjW8i3hwsQ==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-transform-es2015-modules-amd": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-5SUB8zZH5j1omVktHXVzVGMhmC/yokWTFixJZ0CqSRuAwoFTuaBgHsj/T1QtmMZbvrJ3PsV8uCrg8zO7Z2yUgw==",
-          "dev": true,
-          "requires": {
-            "babel-helper-replace-supers": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-+Zq3JmnJmfM+bVURFDkwhSdu9rOrkSAtc8ePdnOMYQTCBsUhnujJMZWWylS/N1KL8oDAK/2dolk9iUisV1SnGw==",
-          "dev": true,
-          "requires": {
-            "babel-helper-call-delegate": "7.0.0-alpha.19",
-            "babel-helper-get-function-arity": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-j5LhWZWZYP4OTiaigQQmoXmLE0k450T4j5e2fJWhBsz5WKq2YSnS0BwHAtlvDH5xFJ6julhbAxf0iWzTmDAbFA==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-spread": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-GYX7PRyY0cs+/yl3DBfUxlL2KJ0FQ9D97cxLeRjw6eiz0ql5fuzsIWwhDie7/ccqSNec56E+d/L/z4mvnHabMg==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-vdwlh1UD3UTdCBiRmNXensfRO/v3J6VyiIHx7HePnwGRS3Dh8+ePOptdSD8jR9ucC9sAbb/0fkK7tV+jo7I7Tg==",
-          "dev": true,
-          "requires": {
-            "babel-helper-regex": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-bPI0ZJ1nOGzLKjKb0aRgAzYzhEO2yji/3HBoOaD7t0frCOV7eWYDexHrZEMWXDD5DtylzIiCjYQvb2VnbYC8Fg==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-d0ishyCrWuTCmU6FRsKUaH/jZcirNC6478eldvvwV0Ufj8g0LRP2HvYq3j8B4ismtceRINfWIZ6D4mEla385gQ==",
-          "dev": true
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-Co4zk9kF6wxPm+8MKN1hzgCDOY/Ewd24odfCmMzbsXaqqeh3cShF/8gBNuewHGca1m3Hl22zVxaWyXswJ0MwHA==",
-          "dev": true,
-          "requires": {
-            "babel-helper-regex": "7.0.0-alpha.19",
-            "regexpu-core": "4.1.1"
-          }
-        },
-        "babel-plugin-transform-regenerator": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-Muw6vf0Hx85mAy8DR00VOPl/oQSxsqDGqEtnp9o8aTrtOg5jNfFZR5IKLz9xawPni2LEf0HerG4iYDSqmvk7NQ==",
-          "dev": true,
-          "requires": {
-            "regenerator-transform": "0.9.11"
-          }
-        },
-        "babel-plugin-transform-strict-mode": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-xVgVVUQrULvE2ZPtTu9uUYn7z9MC3IeVQ0gwogQzt1aYGm/e0wHvqAVXLyxBZBWMBkOSqoi1tnu58IgmcnP9OQ==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-traverse": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "7.0.0-alpha.19",
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "babylon": "7.0.0-beta.19",
-            "debug": "2.6.8",
-            "globals": "10.0.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.19",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
-          }
-        },
-        "globals": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.0.0.tgz",
-          "integrity": "sha512-kxN6RfO/HLQcHV2yI48enVP37K7vlpTl3vcLCwYkRidzO/GjOOK7jQUD9LvhPeSvbiAsnSDGEd5SDVVa9EeimQ==",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        },
-        "regexpu-core": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.1.tgz",
-          "integrity": "sha512-7GxoLPMhj0ng8DOtWHeTFTXna911T05C3Mm5z7W7ODgX6vIAMfCgnWpmMplzraOtv9Fbu5J4gHhuMCKE+Xzsqg==",
-          "dev": true,
-          "requires": {
-            "regenerate": "1.3.2",
-            "regenerate-unicode-properties": "5.1.0",
-            "regjsgen": "0.3.0",
-            "regjsparser": "0.2.1",
-            "unicode-match-property-ecmascript": "1.0.2",
-            "unicode-match-property-value-ecmascript": "1.0.1"
-          }
-        },
-        "regjsgen": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
-          "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
-          "dev": true
-        },
-        "regjsparser": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
-          "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
-          "dev": true,
-          "requires": {
-            "jsesc": "0.5.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-runtime": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0",
-        "regenerator-runtime": "0.10.5"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       }
     },
-    "babel-template": {
-      "version": "7.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-alpha.19.tgz",
-      "integrity": "sha512-96IEIj99ubXPjZyF2V/ZZrjSUAO3baNtOP16Qlibd9q5Hh4WVm+Xv2mOqdjABJG96N991EAtNXk3+JibJGxnWQ==",
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-traverse": "7.0.0-alpha.19",
-        "babel-types": "7.0.0-alpha.19",
-        "babylon": "7.0.0-beta.18",
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
         "lodash": "4.17.4"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "babel-code-frame": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-+eEVwCwCRd4drQsKQZ1Uim0ECzNJUjgxEx+mdTxh6JX6mqNjjKbbdJMe4zn3QtsK8eiCHJawt2UjxhisH3+tog==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-RBrnSG/Y6fI1HuCc2t1q1bBOcWRK8vvRzzthjfBKhQBrDWJBa86r8EvbqTJUnYl2qOUtY9D8djdhTBL2uvit5Q==",
-          "dev": true,
-          "requires": {
-            "babel-helper-get-function-arity": "7.0.0-alpha.19",
-            "babel-template": "7.0.0-alpha.19",
-            "babel-traverse": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-j46M8BCNsllimyHR0uejSM70h0/P0DVOgm02ul+OQ3gurXhdQ1SFmD/VDabBPu6GTLR/UwdCB8olkzc64r3i5g==",
-          "dev": true,
-          "requires": {
-            "babel-types": "7.0.0-alpha.19"
-          }
-        },
-        "babel-messages": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-uvK8YhgjYrKQGZchyI8fGPQBddQSPmX2PcVG5CombkNONzL4i916LxnjhusQoZRi9FGNIe7C/UANDOlWEX3Qjw==",
-          "dev": true
-        },
-        "babel-traverse": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-nW2yJJjVTKnvmqWSh8jsUAJaQMhTDhD4CPdy7hLhOTxGORPKP+V5ax8wQCHhIbgU+lV2oJ9iqJUpvGvjs7GRwA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "7.0.0-alpha.19",
-            "babel-helper-function-name": "7.0.0-alpha.19",
-            "babel-messages": "7.0.0-alpha.19",
-            "babel-types": "7.0.0-alpha.19",
-            "babylon": "7.0.0-beta.19",
-            "debug": "2.6.8",
-            "globals": "10.0.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          },
-          "dependencies": {
-            "babylon": {
-              "version": "7.0.0-beta.19",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-              "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-              "dev": true
-            }
-          }
-        },
-        "babel-types": {
-          "version": "7.0.0-alpha.19",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-alpha.19.tgz",
-          "integrity": "sha512-EY9Qn4xGxpUBhLs87s9K8k5bYI5bfIrRXobd5kHP0yBGWvu1bzM8oJ9w/xXTX+mdaRFs2w5V8bBP9in6GTHhGg==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "2.0.0"
-          }
-        },
         "babylon": {
-          "version": "7.0.0-beta.18",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.18.tgz",
-          "integrity": "sha1-XCPuP9tmNYqr83iXeTGcW3iiM8c=",
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
+            "ms": "2.0.0"
           }
         },
         "globals": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.0.0.tgz",
-          "integrity": "sha512-kxN6RfO/HLQcHV2yI48enVP37K7vlpTl3vcLCwYkRidzO/GjOOK7jQUD9LvhPeSvbiAsnSDGEd5SDVVa9EeimQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         }
       }
     },
-    "babel-traverse": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
-    },
     "babel-types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
+        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.4",
         "to-fast-properties": "1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.17.4",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+      "version": "7.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.35.tgz",
+      "integrity": "sha512-Y2o5scalPPlI6eOYMat6iqoM8akjqkAv9cXUN/7YNe3FANAsAGcF5L2u6XiUtBECvhyf7LeZYyzNYnjk43Vffg==",
       "dev": true
     },
     "balanced-match": {
@@ -1517,9 +920,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "boom": {
@@ -1546,6 +949,33 @@
         "repeating": "2.0.1",
         "string-width": "1.0.2",
         "widest-line": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -1570,13 +1000,13 @@
       }
     },
     "browserslist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.0.tgz",
-      "integrity": "sha512-jDr9Mea+n+FwI+kR0ce7rXCFBoM7hbL80G/th7oPxuNSK4V5J3LPMHB5vykjeI2h7fgSihBbSdoJPmzUC0606Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
+      "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000712",
-        "electron-to-chromium": "1.3.17"
+        "caniuse-lite": "1.0.30000784",
+        "electron-to-chromium": "1.3.29"
       }
     },
     "buf-compare": {
@@ -1623,9 +1053,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000712",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000712.tgz",
-      "integrity": "sha1-tHMt7yRZIk8/eMapuhA6v8xwVnA=",
+      "version": "1.0.30000784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz",
+      "integrity": "sha1-EpztdOmhKApEGIC2zSvOMO9Z5sA=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1641,16 +1071,14 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "4.5.0"
       }
     },
     "circular-json": {
@@ -1681,9 +1109,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "co": {
@@ -1705,9 +1133,9 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -1741,9 +1169,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "concat-map": {
@@ -1795,9 +1223,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "core-assert": {
@@ -1810,9 +1238,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
       "dev": true
     },
     "core-util-is": {
@@ -1822,9 +1250,9 @@
       "dev": true
     },
     "coveralls": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
       "requires": {
         "js-yaml": "3.6.1",
@@ -1843,12 +1271,6 @@
             "argparse": "1.0.9",
             "esprima": "2.7.3"
           }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
         }
       }
     },
@@ -1895,7 +1317,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.26"
+        "es5-ext": "0.10.37"
       }
     },
     "dashdash": {
@@ -1926,9 +1348,9 @@
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -2042,9 +1464,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.17",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz",
-      "integrity": "sha1-QcE0V8xxZsXBXnZ65h2GqMrN7l0=",
+      "version": "1.3.29",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.29.tgz",
+      "integrity": "sha1-elgja5VGjD52YAkTSFItZddzazY=",
       "dev": true
     },
     "error-ex": {
@@ -2057,23 +1479,23 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.26",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
-      "integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2084,8 +1506,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -2098,8 +1520,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
@@ -2111,7 +1533,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26"
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
@@ -2121,8 +1543,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2152,21 +1574,21 @@
       "requires": {
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
         "es6-map": "0.1.5",
         "escope": "3.6.0",
-        "espree": "3.5.0",
+        "espree": "3.5.2",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "1.3.1",
         "glob": "7.0.6",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
+        "is-my-json-valid": "2.17.1",
+        "is-resolvable": "1.0.1",
         "js-yaml": "3.5.5",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
@@ -2183,6 +1605,48 @@
         "table": "3.8.3",
         "text-table": "0.2.0",
         "user-home": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "eslint-config-xo": {
@@ -2203,6 +1667,33 @@
         "plur": "2.1.2",
         "repeating": "2.0.1",
         "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "eslint-import-resolver-node": {
@@ -2211,9 +1702,20 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "object-assign": "4.1.1",
-        "resolve": "1.1.7"
+        "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-ava": {
@@ -2224,7 +1726,7 @@
       "requires": {
         "arrify": "1.0.1",
         "deep-strict-equal": "0.1.0",
-        "espree": "3.5.0",
+        "espree": "3.5.2",
         "espurify": "1.7.0",
         "lodash.rest": "4.0.5",
         "multimatch": "2.1.0",
@@ -2246,7 +1748,7 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "doctrine": "1.3.0",
         "es6-map": "0.1.5",
         "es6-set": "0.1.5",
@@ -2262,6 +1764,15 @@
         "pkg-up": "1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
@@ -2305,12 +1816,12 @@
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -2326,7 +1837,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0"
+        "core-js": "2.5.3"
       }
     },
     "esrecurse": {
@@ -2358,7 +1869,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26"
+        "es5-ext": "0.10.37"
       }
     },
     "eventemitter2": {
@@ -2446,7 +1957,7 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -2510,9 +2021,9 @@
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -2560,7 +2071,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "mime-types": "2.1.17"
       }
     },
     "fs.realpath": {
@@ -2570,9 +2081,9 @@
       "dev": true
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "generate-function": {
@@ -2659,9 +2170,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
       "dev": true
     },
     "globby": {
@@ -2723,7 +2234,7 @@
         "grunt-known-options": "1.1.0",
         "grunt-legacy-log": "1.0.0",
         "grunt-legacy-util": "1.0.0",
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "js-yaml": "3.5.5",
         "minimatch": "3.0.4",
         "nopt": "3.0.6",
@@ -2741,6 +2252,14 @@
         "grunt-known-options": "1.1.0",
         "nopt": "3.0.6",
         "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
       }
     },
     "grunt-contrib-clean": {
@@ -2750,13 +2269,13 @@
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "rimraf": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "7.0.6"
@@ -2810,10 +2329,35 @@
         "lodash": "4.3.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "lodash": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
           "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -2848,9 +2392,36 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "commander": "2.11.0",
-        "is-my-json-valid": "2.16.0",
+        "commander": "2.12.2",
+        "is-my-json-valid": "2.17.1",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "has": {
@@ -2859,7 +2430,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -2901,7 +2472,7 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
+        "os-homedir": "1.0.1",
         "os-tmpdir": "1.0.2"
       }
     },
@@ -2929,15 +2500,15 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -2972,9 +2543,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -2987,7 +2558,7 @@
         "ansi-regex": "2.1.1",
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "figures": "1.7.0",
         "lodash": "4.17.4",
         "readline2": "1.0.1",
@@ -2996,6 +2567,33 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "invariant": {
@@ -3008,9 +2606,9 @@
       }
     },
     "irregular-plurals": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
-      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
     "is-arrayish": {
@@ -3020,9 +2618,9 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -3108,9 +2706,9 @@
       }
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -3162,13 +2760,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -3215,13 +2813,10 @@
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -3374,7 +2969,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "latest-version": {
@@ -3506,6 +3101,33 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "loose-envify": {
@@ -3565,14 +3187,6 @@
         "read-pkg-up": "1.0.1",
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "micromatch": {
@@ -3593,22 +3207,22 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mime-db": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "1.30.0"
       }
     },
     "minimatch": {
@@ -3621,9 +3235,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mkdirp": {
@@ -3633,6 +3247,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -3680,7 +3302,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -3701,7 +3323,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "number-is-nan": {
@@ -5195,9 +4817,9 @@
       }
     },
     "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
       "dev": true
     },
     "os-tmpdir": {
@@ -5212,7 +4834,7 @@
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
+        "os-homedir": "1.0.1",
         "os-tmpdir": "1.0.2"
       }
     },
@@ -5344,7 +4966,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "1.3.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pluralize": {
@@ -5372,9 +4994,9 @@
       "dev": true
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process-nextick-args": {
@@ -5438,7 +5060,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5449,29 +5071,23 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -5548,45 +5164,56 @@
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.0.tgz",
-      "integrity": "sha512-xqlmGBklpiDwqLSkXK4xz0rvr3iIQqMt/HsqA3GWei0wpIcybLoujLppewotKaxzV4KwMcMlunj7c89PIeyv+g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
+      "integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.2"
+        "regenerate": "1.3.3"
       }
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.2.tgz",
+      "integrity": "sha512-mo4Xl+yQEvkGnQ6BU+mO4Dit6N8ndtwIJ6fq8naCbNiizlh3DUce/vm1W2GuTuMsckc6+w+TexG3nOdf9niNaQ==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "private": "0.1.7"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regexpu-core": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
+      "integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3",
+        "regenerate-unicode-properties": "5.1.3",
+        "regjsgen": "0.3.0",
+        "regjsparser": "0.2.1",
+        "unicode-match-property-ecmascript": "1.0.3",
+        "unicode-match-property-value-ecmascript": "1.0.1"
       }
     },
     "registry-auth-token": {
@@ -5595,7 +5222,7 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1",
+        "rc": "1.2.2",
         "safe-buffer": "5.1.1"
       }
     },
@@ -5605,13 +5232,36 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1"
+        "rc": "1.2.2"
+      }
+    },
+    "regjsgen": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
+      "integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
+      "integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -5654,11 +5304,11 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
+        "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
         "qs": "6.3.2",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.4.3",
         "uuid": "3.1.0"
       }
@@ -5682,10 +5332,13 @@
       }
     },
     "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-cwd": {
       "version": "1.0.0",
@@ -5797,9 +5450,9 @@
       }
     },
     "source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "spdx-correct": {
@@ -5859,15 +5512,6 @@
       "integrity": "sha1-lAy4L8z6hOj/Lz/fKT/ngBa+zNE=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5877,6 +5521,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -5919,10 +5572,13 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
     },
     "symbol": {
       "version": "0.2.3",
@@ -5950,6 +5606,25 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -5964,16 +5639,24 @@
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
           }
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -5983,10 +5666,10 @@
       "integrity": "sha1-36w+zxSshUe7rSW70Wzyw3Q/Zc8=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "clean-yaml-object": "0.1.0",
         "color-support": "1.1.3",
-        "coveralls": "2.13.1",
+        "coveralls": "2.13.3",
         "deeper": "2.1.0",
         "foreground-child": "1.5.6",
         "glob": "7.0.6",
@@ -6009,12 +5692,6 @@
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
           "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
           "dev": true
-        },
-        "os-homedir": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-          "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
-          "dev": true
         }
       }
     },
@@ -6025,7 +5702,7 @@
       "dev": true,
       "requires": {
         "color-support": "1.1.3",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "diff": "1.4.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.0.6",
@@ -6033,6 +5710,17 @@
         "readable-stream": "2.3.3",
         "tap-parser": "2.2.3",
         "unicode-length": "1.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "tap-parser": {
@@ -6077,15 +5765,15 @@
       "dev": true
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"
@@ -6101,12 +5789,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tunnel-agent": {
@@ -6144,9 +5826,9 @@
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.1.tgz",
-      "integrity": "sha512-c9juFqQ+es3yrZYrWPgykz4RjhTNv5PEneMmNEXGTAw6RqiCzSl1w4uDB9rxCGasiovwzBeGitMJYO+u9jU7Zg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-iG/2t0F2LAU8aZYPkX5gi7ebukHnr3sWFESpb+zPQeeaQwOkfoO6ZW17YX7MdRPNG9pCy+tjzGill+Ah0Em0HA==",
       "dev": true
     },
     "unicode-length": {
@@ -6160,12 +5842,12 @@
       }
     },
     "unicode-match-property-ecmascript": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-1jUYUJTBqPjcSd5fzO5u7Q0QlFMgGZWyN8DgQL1VkvhLn3Ai4gAyzIB9o9D03PMJJ2SFoDyE7x8aVl3whPjuZg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.3.tgz",
+      "integrity": "sha512-nFcaBFcr08UQNF15ZgI5ISh3yUnQm7SJRRxwYrL5VYX46pS+6Q7TCTv4zbK+j6/l7rQt0mMiTL2zpmeygny6rA==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "1.0.1",
+        "unicode-canonical-property-names-ecmascript": "1.0.3",
         "unicode-property-aliases-ecmascript": "1.0.3"
       }
     },
@@ -6201,6 +5883,33 @@
         "lazy-req": "1.1.0",
         "semver-diff": "2.1.0",
         "xdg-basedir": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "url-parse-lax": {
@@ -6218,7 +5927,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "1.0.1"
       }
     },
     "util-deprecate": {
@@ -6342,7 +6051,7 @@
       "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "1.0.1"
       }
     },
     "xo": {
@@ -6353,7 +6062,7 @@
       "requires": {
         "arrify": "1.0.1",
         "babel-eslint": "6.1.2",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "deep-assign": "1.0.0",
         "eslint": "2.13.1",
         "eslint-config-xo": "0.15.4",
@@ -6379,6 +6088,15 @@
         "xo-init": "0.3.6"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "get-stdin": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
@@ -6401,14 +6119,6 @@
         "read-pkg-up": "1.0.1",
         "the-argv": "1.0.0",
         "write-pkg": "1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "compiler"
   ],
   "peerDependencies": {
-    "babel-core": "^6.0.0 || ^7.0.0-alpha",
+    "@babel/core": "7.0.0-beta.35",
     "grunt": ">=0.4.0"
   },
   "devDependencies": {
-    "babel-core": "7.0.0-alpha.19",
-    "babel-preset-env": "2.0.0-alpha.19",
+    "@babel/core": "7.0.0-beta.35",
+    "@babel/preset-env": "7.0.0-beta.35",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 ## Install
 
 ```
-$ npm install --save-dev grunt-babel babel-core babel-preset-env
+$ npm install --save-dev grunt-babel @babel/core @babel/preset-env
 ```
 
 

--- a/tasks/babel.js
+++ b/tasks/babel.js
@@ -1,6 +1,6 @@
 'use strict';
 var path = require('path');
-var babel = require('babel-core');
+var babel = require('@babel/core');
 
 module.exports = function (grunt) {
 	grunt.registerMultiTask('babel', 'Use next generation JavaScript, today', function () {


### PR DESCRIPTION
Hi! Opened this Pull request to get insight and get the discussion going on how to move forward with grunt-babel consuming and requiring @babel/core instead of babel-core. Thanks!

===
- Updating dependencies
- Require @babel/core instead of babel-core
- Updated lock
