### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ yarn add --dev grunt-babel @babel/core @babel/preset-env
 
 For Babel 6.x and grunt-babel v7
 ```sh
-$ yarn add --dev grunt-babel@7 @babel-core babel-preset-env
+$ yarn add --dev grunt-babel@7 babel-core babel-preset-env
 ```
 Note: See the [7.x branch](https://github.com/babel/grunt-babel/tree/7.x) for more examples of
 usage of Babel 6.x. This README is primarily applicable for Babel 7.x


### PR DESCRIPTION
I suspect this is a typo

```
$ yarn add --dev grunt-babel@7 @babel-core babel-preset-env
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "@babel-core": Tags may not have any characters that encodeURIComponent encodes.
```