### PR TITLE
Deal with res is null.

### DIFF
--- a/tasks/babel.js
+++ b/tasks/babel.js
@@ -55,6 +55,12 @@ module.exports = function(grunt) {
           return acc
             .then(() => babel.transformFileAsync(filename, opts))
             .then(res => {
+              if (!res) {
+                // Simply copy file as nothing changed
+                grunt.file.write(el.dest, grunt.file.read(filename));
+                return;
+              }
+
               let sourceMappingURL = "";
 
               if (res.map) {


### PR DESCRIPTION
In some cases nothing changed and res will be just null. 
In this case the task will fail with "Cannot read property 'map' of null".

As the destination might be different from the source the file should be just copied.