### PR TITLE
Extend peer dependency range to include both Babel 7 and Babel 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "compiler"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.0.0 || ^8.0.0",
     "grunt": ">=0.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.0.0 || ^8.0.0",
     "@babel/preset-env": "^7.0.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.3.0",


### PR DESCRIPTION
See issue #127 